### PR TITLE
Update queues.mdx

### DIFF
--- a/apps/docs/content/guides/queues.mdx
+++ b/apps/docs/content/guides/queues.mdx
@@ -3,7 +3,7 @@ title: Supabase Queues
 subtitle: 'Durable Message Queues with Guaranteed Delivery in Postgres'
 ---
 
-Supabase Queues is a Postgres-native durable Message Queue system with guaranteed delivery built on the [pgmq database extension](https://github.com/tembo-io/pgmq). It offers developers a seamless way to persist and process Messages in the background while improving the resiliency and scalability of their applications and services.
+Supabase Queues is a Postgres-native durable Message Queue system with guaranteed delivery built on the [pgmq database extension](https://github.com/pgmq/pgmq). It offers developers a seamless way to persist and process Messages in the background while improving the resiliency and scalability of their applications and services.
 
 Queues couples the reliability of Postgres with the simplicity Supabase's platform and developer experience, enabling developers to manage Background Tasks with zero configuration.
 
@@ -31,4 +31,4 @@ Queues couples the reliability of Postgres with the simplicity Supabase's platfo
 
 - [Quickstart](/docs/guides/queues/quickstart)
 - [API Reference](/docs/guides/queues/api)
-- [`pgmq` GitHub Repository](https://github.com/tembo-io/pgmq)
+- [`pgmq` GitHub Repository](https://github.com/pgmq/pgmq)


### PR DESCRIPTION
changing pgmq repo address to current repo

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

Please link any relevant issues here.
referenced to old pgmq repo from tembo
## What is the new behavior?
it no pointed to [pgmq](https://github.com/pgmq/pgmq)

