### PR TITLE
Update Integrations.constants.tsx

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -62,10 +62,10 @@ const supabaseIntegrations: IntegrationDefinition[] = [
       <Layers className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
     ),
     description: 'Lightweight message queue in Postgres',
-    docsUrl: 'https://github.com/tembo-io/pgmq',
+    docsUrl: 'https://github.com/pgmq/pgmq',
     author: {
       name: 'pgmq',
-      websiteUrl: 'https://github.com/tembo-io/pgmq',
+      websiteUrl: 'https://github.com/pgmq/pgmq',
     },
     navigation: [
       {


### PR DESCRIPTION
changing pgmq repo address to current repo

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

Please link any relevant issues here.
referenced to old pgmq repo from tembo
## What is the new behavior?
it no pointed to [pgmq](https://github.com/pgmq/pgmq)

