### PR TITLE
Update 2024-12-05-supabase-queues.mdx

### DIFF
--- a/apps/www/_blog/2024-12-05-supabase-queues.mdx
+++ b/apps/www/_blog/2024-12-05-supabase-queues.mdx
@@ -31,9 +31,9 @@ Supabase Queues is a Postgres-native, durable Message Queue with guaranteed deli
 
 <Admonition>
 
-Supabase Queues is built on the [pgmq](https://github.com/tembo-io/pgmq) extension by the team at [Tembo](https://github.com/tembo-io).
+Supabase Queues is built on the [pgmq](https://github.com/pgmq/pgmq) extension by the team at [Tembo](https://github.com/tembo-io).
 
-It's a Supabase policy to [support existing tools](/docs/guides/getting-started/architecture#support-existing-tools) wherever possible, and the Tembo team have generously licensed their extension with the OSI-compatible [PostgreSQL license](https://github.com/tembo-io/pgmq?tab=PostgreSQL-1-ov-file).
+It's a Supabase policy to [support existing tools](/docs/guides/getting-started/architecture#support-existing-tools) wherever possible, and the Tembo team have generously licensed their extension with the OSI-compatible [PostgreSQL license](https://github.com/pgmq/pgmq?tab=PostgreSQL-1-ov-file).
 
 We're very thankful to all the contributors and we look forward to working with the Tembo community.
 


### PR DESCRIPTION
changing pgmq repo address to current repo

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

Please link any relevant issues here.
referenced to old pgmq repo from tembo
## What is the new behavior?
it no pointed to [pgmq](https://github.com/pgmq/pgmq)

